### PR TITLE
Added support for inner/base http client in Firestore constructors.

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -25,6 +25,17 @@ jobs:
     - name: Check that code is formatted
       run: ./scripts/check_code_is_formatted.sh
 
+  run-remote-tests:
+    runs-on: ubuntu-latest
+    container:
+      image:  google/dart:2.12-dev
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run all tests that contact the remote Firestore database.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./scripts/run_remote_tests.sh
+
   # Unimplemented. See: https://github.com/SharezoneApp/cloud_firestore_server/issues/3 
   # test:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -34,7 +34,10 @@ jobs:
     - name: Run all tests that contact the remote Firestore database.
       env:
         FIRESTORE_CREDENTIALS: ${{ secrets.FIRESTORE_CREDENTIALS }}
-      run: ./scripts/run_remote_tests.sh
+      # Terraform base64 encodes the credentials so we decode them here.
+      run: |
+        FIRESTORE_CREDENTIALS=$(echo $FIRESTORE_CREDENTIALS | base64 --decode)
+        ./scripts/run_remote_tests.sh
 
   # Unimplemented. See: https://github.com/SharezoneApp/cloud_firestore_server/issues/3 
   # test:

--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run all tests that contact the remote Firestore database.
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FIRESTORE_CREDENTIALS: ${{ secrets.FIRESTORE_CREDENTIALS }}
       run: ./scripts/run_remote_tests.sh
 
   # Unimplemented. See: https://github.com/SharezoneApp/cloud_firestore_server/issues/3 

--- a/cloud_firestore_server/dart_test.yaml
+++ b/cloud_firestore_server/dart_test.yaml
@@ -1,0 +1,3 @@
+tags:
+  emulator:
+  remote:

--- a/cloud_firestore_server/development.md
+++ b/cloud_firestore_server/development.md
@@ -14,5 +14,8 @@ $  firebase emulators:start --only firestore
 
 Now you can run the tests using:
 ```
-$ dart --no-sound-null-safety test
+$ dart --no-sound-null-safety test --exclude-tags remote
 ```
+
+This excludes the tests that connect to a real Firestore service and thus need valid credentials.
+These will run on Github and have the credentials provided via the environment.

--- a/cloud_firestore_server/lib/cloud_firestore_server.dart
+++ b/cloud_firestore_server/lib/cloud_firestore_server.dart
@@ -1,5 +1,7 @@
 import 'package:cloud_firestore_server/src/document_snapshot.dart';
 import 'package:meta/meta.dart';
+// ignore: import_of_legacy_library_into_null_safe
+import 'package:http/http.dart' as http;
 
 import 'src/bulk_writer.dart';
 import 'src/collection_group.dart';
@@ -50,9 +52,12 @@ class Firestore {
   }
 
   @visibleForTesting
-  static Future<Firestore> internal(
-      {String url = 'https://firestore.googleapis.com/'}) async {
-    return Firestore._(await createTestInstanceResources(rootUrl: url));
+  static Future<Firestore> internal({
+    String url = 'https://firestore.googleapis.com/',
+    http.Client? innerClient,
+  }) async {
+    return Firestore._(await createTestInstanceResources(
+        rootUrl: url, innerClient: innerClient));
   }
 
   Firestore._(this._instanceResources);

--- a/cloud_firestore_server/lib/cloud_firestore_server.dart
+++ b/cloud_firestore_server/lib/cloud_firestore_server.dart
@@ -42,13 +42,18 @@ class Firestore {
   /// Is usually "projects/[YOUR-PROJECT-ID]/databases/(default)"
   String get formattedName => _instanceResources.databasePath;
 
-  static Future<Firestore> newInstance(
-      {ServiceAccountCredentials? credentials}) async {
+  static Future<Firestore> newInstance({
+    ServiceAccountCredentials? credentials,
+    http.Client? innerClient,
+  }) async {
     /// Haven't tested [ServiceAccountCredentials.applicationDefault] yet.
     final _credentials =
         credentials ?? ServiceAccountCredentials.applicationDefault();
 
-    return Firestore._(await createInstanceResources(_credentials));
+    return Firestore._(await createInstanceResources(
+      _credentials,
+      innerClient: innerClient,
+    ));
   }
 
   @visibleForTesting

--- a/cloud_firestore_server/lib/src/internal/instance_resources.dart
+++ b/cloud_firestore_server/lib/src/internal/instance_resources.dart
@@ -27,14 +27,19 @@ class InstanceResources {
 /// from googleapis. Uses googleapis_auth to create an
 /// [googleapis_auth.AuthClient] for authenticated calls to Firestore.
 Future<InstanceResources> createInstanceResources(
-    ServiceAccountCredentials credentials) async {
+  ServiceAccountCredentials credentials, {
+  http.Client? innerClient,
+}) async {
   final _creds = googleapis_auth.ServiceAccountCredentials(
       credentials.email,
       googleapis_auth.ClientId.serviceAccount(credentials.clientId),
       credentials.privateKey);
 
-  const _scopes = [FirestoreApi.DatastoreScope];
-  final client = await googleapis_auth.clientViaServiceAccount(_creds, _scopes);
+  final client = await googleapis_auth.clientViaServiceAccount(
+    _creds,
+    [FirestoreApi.DatastoreScope],
+    baseClient: innerClient,
+  );
 
   final ProjectsDatabasesDocumentsResourceApi api =
       FirestoreApi(client).projects.databases.documents;
@@ -47,9 +52,11 @@ Future<InstanceResources> createInstanceResources(
 }
 
 /// Creates unauthenticated [InstanceResources] for the use of offline testing.
-Future<InstanceResources> createTestInstanceResources(
-    {required String rootUrl}) async {
-  final client = http.Client();
+Future<InstanceResources> createTestInstanceResources({
+  required String rootUrl,
+  http.Client? innerClient,
+}) async {
+  final client = innerClient ?? http.Client();
 
   final ProjectsDatabasesDocumentsResourceApi api =
       FirestoreApi(client, rootUrl: rootUrl).projects.databases.documents;

--- a/cloud_firestore_server/test/inner_http_client_test.dart
+++ b/cloud_firestore_server/test/inner_http_client_test.dart
@@ -54,12 +54,9 @@ void runTests(
     test(
         'passed to Firestore.internal using googleapis gets the requests sent to the Firestore backend.',
         () async {
-      final requestsBefore = List.from(innerClient.sentRequests);
       await firestore.doc('col/doc').get().ignoreResultAndExceptions();
-      final requestsAfter = List.from(innerClient.sentRequests);
 
-      expect(requestsBefore, isEmpty);
-      expect(requestsAfter, hasLength(1));
+      expect(innerClient.sentRequests, isNotEmpty);
     });
 
     /// The query method is a custom implementation we have to test seperately
@@ -70,16 +67,13 @@ void runTests(
     test(
         'passed to Firestore.internal using own query implementation gets the requests sent to the Firestore backend.',
         () async {
-      final requestsBefore = List.from(innerClient.sentRequests);
       await firestore
           .collection('col')
           .where('foo', isEqualTo: 'bar')
           .get()
           .ignoreResultAndExceptions();
-      final requestsAfter = List.from(innerClient.sentRequests);
 
-      expect(requestsBefore, isEmpty);
-      expect(requestsAfter, hasLength(1));
+      expect(innerClient.sentRequests, isNotEmpty);
     });
   });
 }

--- a/cloud_firestore_server/test/inner_http_client_test.dart
+++ b/cloud_firestore_server/test/inner_http_client_test.dart
@@ -8,6 +8,12 @@ import 'package:test/test.dart';
 // Easier to read in tests:
 // ignore_for_file: prefer_function_declarations_over_variables
 
+/// Returns the credentials for the live Firestore test database from the
+/// environment variable FIRESTORE_CREDENTIALS.
+/// This method is called to run the remote tests on Github Actions.
+/// The credentials are passed via Action Secrets.
+/// Locally the remote tests can be skipped via
+/// `dart --no-sound-null-safety test --exclude-tags remote`.
 ServiceAccountCredentials getCredentialsFromEnvironment() {
   final _creds = Platform.environment['FIRESTORE_CREDENTIALS'];
   if (_creds == null) {
@@ -19,6 +25,8 @@ ServiceAccountCredentials getCredentialsFromEnvironment() {
 }
 
 Future<void> main() async {
+  /// We seperate both as the remote tests can only be run on Github Actions as
+  /// locally one might not have the necessary credentials.
   group('(using Emulator)', () {
     runTests((innerClient) => Firestore.internal(
           url: 'http://localhost:8080/',
@@ -54,9 +62,10 @@ void runTests(
       expect(requestsAfter, hasLength(1));
     });
 
-    /// Here I test my own method implementation because after more than 3 years
-    /// the bug that querying with the googleapis package does not work is still
-    /// not fixed :(
+    /// The query method is a custom implementation we have to test seperately
+    /// from the implementation of the googleapis package.
+    /// The query implementation is custom made as after 3 years the bug that
+    /// querying with the googleapis package does not work is still not fixed :(
     /// https://github.com/dart-lang/googleapis/issues/25
     test(
         'passed to Firestore.internal using own query implementation gets the requests sent to the Firestore backend.',

--- a/cloud_firestore_server/test/inner_http_client_test.dart
+++ b/cloud_firestore_server/test/inner_http_client_test.dart
@@ -1,0 +1,78 @@
+import 'package:cloud_firestore_server/cloud_firestore_server.dart';
+// ignore: import_of_legacy_library_into_null_safe
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+// Easier to read in tests:
+// ignore_for_file: prefer_function_declarations_over_variables
+
+Future<void> main() async {
+  group('innerClient', () {
+    late Firestore firestore;
+    late SpyingClient innerClient;
+
+    setUp(() async {
+      innerClient = SpyingClient(http.Client());
+      firestore = await Firestore.internal(
+        url: 'http://localhost:8080/',
+        innerClient: innerClient,
+      );
+    });
+    test(
+        'passed to Firestore.internal using googleapis gets the requests sent to the Firestore backend.',
+        () async {
+      final requestsBefore = List.from(innerClient.sentRequests);
+      await firestore.doc('col/doc').get().ignoreResultAndExceptions();
+      final requestsAfter = List.from(innerClient.sentRequests);
+
+      expect(requestsBefore, isEmpty);
+      expect(requestsAfter, hasLength(1));
+    });
+
+    /// Here I test my own method implementation because after more than 3 years
+    /// the bug that querying with the googleapis package does not work is still
+    /// not fixed :(
+    /// https://github.com/dart-lang/googleapis/issues/25
+    test(
+        'passed to Firestore.internal using own query implementation gets the requests sent to the Firestore backend.',
+        () async {
+      final requestsBefore = List.from(innerClient.sentRequests);
+      await firestore
+          .collection('col')
+          .where('foo', isEqualTo: 'bar')
+          .get()
+          .ignoreResultAndExceptions();
+      final requestsAfter = List.from(innerClient.sentRequests);
+
+      expect(requestsBefore, isEmpty);
+      expect(requestsAfter, hasLength(1));
+    });
+  });
+}
+
+extension on Future {
+  /// Ignores the given result or if the Future throws.
+  /// Always returns a successful Future.
+  ///
+  /// In the tests we just care that the Firestore method has used the http
+  /// Client. We don't care if it was successful or failing.
+  Future<void> ignoreResultAndExceptions() async {
+    try {
+      await this;
+      // ignore: empty_catches
+    } catch (e) {}
+  }
+}
+
+class SpyingClient extends http.BaseClient {
+  final http.Client delegate;
+  final List<http.BaseRequest> sentRequests = [];
+
+  SpyingClient(this.delegate);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    sentRequests.add(request);
+    return delegate.send(request);
+  }
+}

--- a/scripts/run_remote_tests.sh
+++ b/scripts/run_remote_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+cd cloud_firestore_server
+dart pub get
+dart --no-sound-null-safety test --tags remote


### PR DESCRIPTION
You can now pass `Firestore` an `package:http` `Client` which can be used to add logging or request modification.  

For example:   
```dart
final firestore = Firestore.newInstance(
  credentials: myCredentials,
  innerClient: LoggingHttpClient(),
);

class LoggingHttpClient extends http.BaseClient {
  final http.Client _delegate = http.Client();

  @override
  Future<http.StreamedResponse> send(http.BaseRequest request) {
    print('Sending request: $request');
    return _delegate.send(request);
  }
}
```

Additionally I added a `run-remote-tests` workflow that runs all tests that call the remote Firestore server.  
Another workflow running the other tests using the emulator needs to be added as well in the future.

This is also a prerequisite to be able to make a regression test for #4.