### PR TITLE
Update `actions/checkout` from v2 to v3 in our GitHub workflows

### DIFF
--- a/.github/workflows/dart.yaml
+++ b/.github/workflows/dart.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
       image:  google/dart:2.12-dev
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check for no lint Errors and no TODO comments
       run: ./scripts/check_for_lint_errors_and_TODO_comments.sh
 
@@ -21,7 +21,7 @@ jobs:
     container:
       image:  google/dart:2.12-dev
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check that code is formatted
       run: ./scripts/check_code_is_formatted.sh
 
@@ -30,7 +30,7 @@ jobs:
     container:
       image:  google/dart:2.12-dev
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run all tests that contact the remote Firestore database.
       env:
         FIRESTORE_CREDENTIALS: ${{ secrets.FIRESTORE_CREDENTIALS }}
@@ -45,7 +45,7 @@ jobs:
   #   container:
   #     image:  google/dart:2.12-dev
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
   #   - name: Run tests
   #     env:
   #       FIRESTORE_CREDENTIALS: ${{ secrets.FIRESTORE_CREDENTIALS }}


### PR DESCRIPTION
Node 12 is deprecated for GitHub Actions. This is the reason why we are getting a warning from GitHub:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates `actions/checkout` from v2 to v3 which should fix the problem.